### PR TITLE
Pin flatbuffers to v2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,6 @@
   },
   "dependencies": {
     "big-integer": "^1.6.51",
-    "flatbuffers": "^2.0.6"
+    "flatbuffers": "2.0.6"
   }
 }


### PR DESCRIPTION
`flatbuffers`, upstream, added a usage of `TextEncoder`, which is not available in React Native without a polyfill.