### PR TITLE
Upgrade cmake version to 3.22.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version '3.10.2'
+            version '3.22.1'
             path "CMakeLists.txt"
         }
     }


### PR DESCRIPTION
Hi,
Without this upgrade, our react native build is failing with following error ->

> Configure project :react-native-fast-rsa
[CXX1300] CMake '3.10.2' was not found in SDK, PATH, or by cmake.dir property.
[CXX1301] - CMake '3.22.1' found in SDK did not satisfy requested version.



Note: Installing cmake manually via android studio did resolve this issue for developers but for automation and CICD we can not have dependency on android studio. So we need this change inside node_modules only.