### PR TITLE
feat: react native >=0.80, android 16kb paging support

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9.0)
 
 set (CMAKE_VERBOSE_MAKEFILE ON)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
 add_library(rsa_bridge SHARED IMPORTED)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,7 @@ android {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
         abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
-        arguments "-DNODE_MODULES_DIR=${rootDir}/../node_modules"
+        arguments "-DNODE_MODULES_DIR=${rootDir}/../node_modules", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
       }
     }
   }


### PR DESCRIPTION
Hello,

this pr fixes https://github.com/jerson/react-native-fast-rsa/issues/96 and https://github.com/jerson/react-native-fast-rsa/issues/94.

Build errors fixed for RN >=0.80 and also for EXPO SDK 54 by using the c++17 standard now as it aligns better with the current NDK toolchain.

Android 16KB paging is supported now. Root RN still compiles with NDK 27 which needs `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`  to be set as mentioned inside the docs: https://developer.android.com/guide/practices/page-sizes#compile-r27

**Paging support before:**
<img width="931" height="344" alt="47cff490a8ad444b4906e452aa91a022" src="https://github.com/user-attachments/assets/61b5e5e3-1633-4cf6-9d7c-3c85e51da52b" />


**Paging support after:**
<img width="718" height="365" alt="50554b455d81ddd19e1c7c6e13c6cf7d" src="https://github.com/user-attachments/assets/37461eff-ffa2-4737-b387-4d62abf04326" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to support flexible page sizes, improving compatibility and potential memory efficiency on newer devices.
  * Upgraded native compilation standard to C++17 to enhance stability, performance, and future compatibility across Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->